### PR TITLE
Fix エディタによってyamlファイルがダブルクウォートに変換されるバグ

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,7 @@ trim_trailing_whitespace = false
 
 [*.{yml,yaml}]
 indent_size = 2
+quote_type = single
 
 [Makefile]
 indent_style = tab

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: '3.9'
 volumes:
   php-fpm-socket:
   db-store:


### PR DESCRIPTION
## 概要
使用してるエディタによってyamlファイルのクウォーテーションが勝手にダブルクウォートに変換される場合があるっぽかったので.editorconfigを変更しました。