### PR TITLE
Fix dbコンテナが/var/log/mysqlのパーミッションエラーで落ちてたバグ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,12 +68,9 @@ services:
         target: /var/lib/mysql
         volume:
           nocopy: true
-    volumes:
       - type: volume
         source: db-log
         target: /var/log/mysql
-        volume:
-          nocopy: true
     environment:
       - MYSQL_DATABASE=${DB_NAME:-laravel_local}
       - MYSQL_USER=${DB_USER:-phper}


### PR DESCRIPTION
## 概要
DBのコンテナがlog用のボリュームに設定されたパーミッションを引き継いで/var/log/mysqlでパーミッションエラーが発生していたのでnocopyオプションを外しました。