### PR TITLE
一件取得のパス名とメソッド名の変更

### DIFF
--- a/backend/app/Exceptions/Handler.php
+++ b/backend/app/Exceptions/Handler.php
@@ -3,6 +3,9 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use \GuzzleHttp\Exception\ServerException;
+use \Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -37,5 +40,31 @@ class Handler extends ExceptionHandler
         $this->reportable(function (Throwable $e) {
             //
         });
+    }
+
+    public function render($request, Throwable $exception)
+    {
+
+        # 認証できていない場合403
+        if ($exception instanceof UnauthorizedHttpException) {
+            return response()->json(
+                [
+                    'message' => $exception->getMessage(),
+                ],
+                Response::HTTP_FORBIDDEN
+            );
+        }
+
+        # サーバーがダウンしている場合500
+        if ($exception instanceof ServerException) {
+            return response()->json(
+                [
+                    'message' => $exception->getMessage(),
+                ],
+                Response::HTTP_INTERNAL_SERVER_ERROR
+            );
+        }
+
+        return parent::render($request, $exception);
     }
 }

--- a/backend/app/Http/Controllers/OfferController.php
+++ b/backend/app/Http/Controllers/OfferController.php
@@ -8,8 +8,6 @@ use App\Http\Requests\GetOffersRequest;
 use App\Http\Requests\StoreOfferRequest;
 use App\Http\Requests\UpdateOfferRequest;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use \Symfony\Component\HttpFoundation\Response;
 use App\Models\Offer;
 use App\Http\Resources\OfferResource;
 use App\Http\Resources\OfferCollection;
@@ -26,73 +24,51 @@ class OfferController extends Controller
     #募集取得API
     public function index(GetOfferRequest $request)
     {
-        try {
-            $fetched_offer = Offer::with([
-                'tags',
-                'tags.genres',
-                'tags.targets',
-                'users',
-            ])
-                ->findOrFail($request->input('offer_id'));
+        $fetched_offer = Offer::with([
+            'tags',
+            'tags.genres',
+            'tags.targets',
+            'users',
+        ])
+            ->findOrFail($request->input('offer_id'));
 
-            return new OfferResource($fetched_offer);
-        } catch (ModelNotFoundException $exception) {
-            return response()->json(
-                $exception,
-                Response::HTTP_UNPROCESSABLE_ENTITY
-            );
-        } catch (\Throwable $exception) {
-            echo $exception->getMessage();
-
-            return response()->json(
-                $exception,
-                Response::HTTP_BAD_REQUEST
-            );
-        }
+        return new OfferResource($fetched_offer);
     }
 
     #募集一覧API
     public function list(GetOffersRequest $request)
     {
-        try {
-            $offer_tags = $request->input('offer_tag_ids');
-            $fetched_offers = Offer::with([
-                'tags',
-                'tags.genres',
-                'tags.targets',
-                'users',
-            ]);
+        $offer_tags = $request->input('offer_tag_ids');
+        $fetched_offers = Offer::with([
+            'tags',
+            'tags.genres',
+            'tags.targets',
+            'users',
+        ]);
 
-            # 募集タグ配列が空の場合は何もしない
-            if (is_array($offer_tags) && !empty($offer_tags)) {
-                $fetched_offers = $fetched_offers
-                    ->whereHas('tags', function ($query) use ($offer_tags) {
-                        $query->whereIn('tags.id', $offer_tags);
-                    });
-            }
-
-            # page番号 * 30件のデータを最新順で取得
+        # 募集タグ配列が空の場合は何もしない
+        if (is_array($offer_tags) && !empty($offer_tags)) {
             $fetched_offers = $fetched_offers
-                ->latest('post_date')
-                ->paginate(30);
-
-            return new OfferCollection($fetched_offers);
-        } catch (\Throwable $exception) {
-            return response()->json(
-                $exception,
-                Response::HTTP_BAD_REQUEST
-            );
+                ->whereHas('tags', function ($query) use ($offer_tags) {
+                    $query->whereIn('tags.id', $offer_tags);
+                });
         }
+
+        # page番号 * 30件のデータを最新順で取得
+        $fetched_offers = $fetched_offers
+            ->latest('post_date')
+            ->paginate(30);
+
+        return new OfferCollection($fetched_offers);
     }
 
     #募集投稿API
     public function post(StoreOfferRequest $request)
     {
-        try {
-            // トランザクションの開始
-            DB::beginTransaction();
+        $created_offer = new Offer();
 
-            $created_offer = new Offer();
+        // トランザクションの開始
+        DB::transaction(function () use ($request, $created_offer) {
             $created_offer->title = $request->input('title');
             $created_offer->target = $request->input('target');
             $created_offer->job = $request->input('job');
@@ -107,38 +83,26 @@ class OfferController extends Controller
 
             $created_offer->tags()->sync($request->input('offer_tag_ids'));
 
-            // 全ての保存処理が成功したので処理を確定する
-            DB::commit();
-
             // リレーションを更新
             $created_offer->load('tags');
+        });
 
-            return new OfferResource($created_offer);
-        } catch (\Throwable $exception) {
-            // 例外が起きたらロールバックを行う
-            DB::rollback();
-
-            return response()->json(
-                $exception,
-                Response::HTTP_BAD_REQUEST
-            );
-        }
+        return new OfferResource($created_offer);
     }
 
     #募集編集API
     public function edit(UpdateOfferRequest $request)
     {
-        try {
-            // トランザクションの開始
-            DB::beginTransaction();
+        $updated_offer = Offer::with([
+            'tags',
+            'tags.genres',
+            'tags.targets',
+            'users',
+        ])
+            ->findOrFail($request->input('offer_id'));
 
-            $updated_offer = Offer::with([
-                'tags',
-                'tags.genres',
-                'tags.targets',
-                'users',
-            ])
-                ->findOrFail($request->input('offer_id'));
+        // トランザクションの開始
+        DB::transaction(function () use ($request, $updated_offer) {
             $updated_offer->title = $request->input('title') ?? $updated_offer->title;
             $updated_offer->target = $request->input('target') ?? $updated_offer->target;
             $updated_offer->job = $request->input('job') ?? $updated_offer->job;
@@ -154,56 +118,26 @@ class OfferController extends Controller
 
             $updated_offer->save();
 
-            // 全ての保存処理が成功したので処理を確定する
-            DB::commit();
-
             // リレーションを更新
             $updated_offer->load('tags');
+        });
 
-            return new OfferResource($updated_offer);
-        } catch (ModelNotFoundException $exception) {
-            return response()->json(
-                $exception,
-                Response::HTTP_UNPROCESSABLE_ENTITY
-            );
-        } catch (\Throwable $exception) {
-            // 例外が起きたらロールバックを行う
-            DB::rollback();
-
-            return response()->json(
-                $exception,
-                Response::HTTP_BAD_REQUEST
-            );
-        }
+        return new OfferResource($updated_offer);
     }
 
     #募集削除API
     public function delete(DestroyOfferRequest $request)
     {
-        try {
-            DB::beginTransaction();
+        // トランザクションの開始
+        DB::transaction(function () use ($request) {
             #中間テーブルとの関連削除も行う
             $destroy_offer = Offer::findOrFail($request->input('offer_id'));
             $destroy_offer->tags()->detach();
             $destroy_offer::destroy($request->input('offer_id'));
+        });
 
-            DB::commit();
-
-            return http_response_code();
-        } catch (ModelNotFoundException $exception) {
-            return response()->json(
-                $exception,
-                Response::HTTP_UNPROCESSABLE_ENTITY
-            );
-        } catch (\Throwable $exception) {
-            // 例外が起きたらロールバックを行う
-            DB::rollback();
-
-            return response()->json(
-                $exception,
-                Response::HTTP_BAD_REQUEST
-            );
-        }
+        # 200を返却
+        return http_response_code();
     }
 
     #応募投稿API


### PR DESCRIPTION
/backend/routes/api.phpの
募集、宣伝、作品について
一件取得のパス名を/offer から /offer/singleに変更しました。

募集と宣伝のメソッド名を変更しました