### PR TITLE
一件取得のパス名とメソッド名の変更

### DIFF
--- a/backend/app/Http/Controllers/OfferController.php
+++ b/backend/app/Http/Controllers/OfferController.php
@@ -24,7 +24,7 @@ use App\Http\Resources\OfferCollection;
 class OfferController extends Controller
 {
     #募集取得API
-    public function index(GetOfferRequest $request)
+    public function single(GetOfferRequest $request)
     {
         try {
             $fetched_offer = Offer::with([

--- a/backend/app/Http/Controllers/PromotionController.php
+++ b/backend/app/Http/Controllers/PromotionController.php
@@ -4,9 +4,9 @@ namespace App\Http\Controllers;
 
 class PromotionController extends Controller
 {
-    public function index()
+    public function single()
     {
-        return 'index';
+        return 'single';
     }
 
     public function list()

--- a/backend/app/Http/Controllers/WorkController.php
+++ b/backend/app/Http/Controllers/WorkController.php
@@ -4,9 +4,9 @@ namespace App\Http\Controllers;
 
 class WorkController extends Controller
 {
-    public function index()
-    {  
-        return 'index';
+    public function single()
+    {
+        return 'single';
     }
 
     public function list()

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -20,7 +20,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 // 募集APIグループ
 Route::group(['prefix' => 'offer', 'as' => 'offer.'], function () {
-    Route::get('/', 'OfferController@index')->name('index');
+    Route::get('single', 'OfferController@single')->name('single');
     Route::get('list', 'OfferController@list')->name('list');
     Route::post('post', 'OfferController@post')->name('post');
     Route::post('edit', 'OfferController@edit')->name('edit');
@@ -30,7 +30,7 @@ Route::group(['prefix' => 'offer', 'as' => 'offer.'], function () {
 
 // 宣伝APIグループ
 Route::group(['prefix' => 'promotion', 'as' => 'promotion.'], function () {
-    Route::get('/', 'PromotionController@index')->name('index');
+    Route::get('single', 'PromotionController@single')->name('single');
     Route::get('list', 'PromotionController@list')->name('list');
     Route::post('post', 'PromotionController@post')->name('post');
     Route::post('edit', 'PromotionController@edit')->name('edit');

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -39,7 +39,7 @@ Route::group(['prefix' => 'promotion', 'as' => 'promotion.'], function () {
 
 // 作品APIグループ
 Route::group(['prefix' => 'work', 'as' => 'work.'], function () {
-    Route::get('/', 'WorkController@index')->name('index');
+    Route::get('single', 'WorkController@single')->name('single');
     Route::get('list', 'WorkController@list')->name('list');
     Route::post('post', 'WorkController@post')->name('post');
     Route::post('edit', 'WorkController@edit')->name('edit');


### PR DESCRIPTION
/backend/routes/api.phpの
募集、宣伝、作品について
一件取得のパス名を/offer から /offer/singleに変更しました。

募集と宣伝のメソッド名を変更しました