### PR TITLE
宣伝削除のバッチ処理を追加

### DIFF
--- a/backend/app/Console/Commands/OfferDelete.php
+++ b/backend/app/Console/Commands/OfferDelete.php
@@ -44,7 +44,7 @@ class OfferDelete extends Command
         DB::transaction(function () {
             # 戻り値は削除件数
             $delete_offers = Offer::whereDate('end_date', '<', date('Y-m-d'))->delete();
-            $message = '[' . date('Y-m-d h:i:s') . ']' . $delete_offers . '件削除';
+            $message = '[' . date('Y-m-d h:i:s') . '] 募集 : ' . $delete_offers . '件削除';
 
             //INFOレベルでメッセージを出力
             $this->info($message);

--- a/backend/app/Console/Commands/PromotionDelete.php
+++ b/backend/app/Console/Commands/PromotionDelete.php
@@ -44,7 +44,7 @@ class PromotionDelete extends Command
         DB::transaction(function () {
             # 戻り値は削除件数
             $delete_promotions = Promotion::whereDate('end_date', '<', date('Y-m-d'))->delete();
-            $message = '[' . date('Y-m-d h:i:s') . ']' . $delete_promotions . '件削除';
+            $message = '[' . date('Y-m-d h:i:s') . '] 宣伝：' . $delete_promotions . '件削除';
 
             //INFOレベルでメッセージを出力
             $this->info($message);

--- a/backend/app/Console/Commands/PromotionDelete.php
+++ b/backend/app/Console/Commands/PromotionDelete.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Promotion;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
+
+class PromotionDelete extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'promotion:delete';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '掲載期間が過ぎた宣伝を削除する';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        // トランザクションの開始
+        DB::transaction(function () {
+            # 戻り値は削除件数
+            $delete_promotions = Promotion::whereDate('end_date', '<', date('Y-m-d'))->delete();
+            $message = '[' . date('Y-m-d h:i:s') . ']' . $delete_promotions . '件削除';
+
+            //INFOレベルでメッセージを出力
+            $this->info($message);
+            //ログを書き出す
+            Log::setDefaultDriver('batch');
+            Log::info($message);
+        });
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -25,8 +25,9 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         // バッチ処理するコマンドをここに記述する
-        // 毎日深夜0時に掲載期間が終了した募集を削除
+        // 毎日深夜0時に掲載期間が終了した募集と宣伝を削除
         $schedule->command('offer:delete')->daily();
+        $schedule->command('promotion:delete')->daily();
     }
 
     /**

--- a/backend/app/Http/Requests/StorePromotionRequest.php
+++ b/backend/app/Http/Requests/StorePromotionRequest.php
@@ -29,7 +29,7 @@ class StorePromotionRequest extends FormRequest
             'picture' => ['nullable', 'url',    'max:255'],
             'link' => ['nullable', 'string', 'max:300'],
             'user_class' => ['required', 'string', 'max:10'],
-            'end_date' => ['required', 'after::today', 'date_format:"Y-m-d"'],
+            'end_date' => ['required', 'after::today', 'date_format:"Y-m-d"', 'before_or_equal:now +90 day'],
             'promotion_tag_ids' => ['nullable', 'array'],
             'promotion_tag_ids.*' => ['integer',  'min:1'],
         ];

--- a/backend/app/Http/Requests/UpdatePromotionRequest.php
+++ b/backend/app/Http/Requests/UpdatePromotionRequest.php
@@ -30,7 +30,7 @@ class UpdatePromotionRequest extends FormRequest
             'picture' => ['nullable', 'url',    'max:255'],
             'link' => ['nullable', 'string', 'max:300'],
             'user_class' => ['required', 'string', 'max:10'],
-            'end_date' => ['required', 'after::today', 'date_format:"Y-m-d"'],
+            'end_date' => ['required', 'after::today', 'date_format:"Y-m-d"', 'before_or_equal:now +90 day'],
             'promotion_tag_ids' => ['nullable', 'array'],
             'promotion_tag_ids.*' => ['integer',  'min:1'],
         ];

--- a/backend/config/logging.php
+++ b/backend/config/logging.php
@@ -67,6 +67,13 @@ return [
             'days' => 14,
         ],
 
+        'batch' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/batch.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => 14,
+        ],
+
         'slack' => [
             'driver' => 'slack',
             'url' => env('LOG_SLACK_WEBHOOK_URL'),


### PR DESCRIPTION
毎日深夜0時に掲載期間を過ぎた宣伝を削除するばバッチ処理を作成。

また、出力するLogファイルをデフォルトからバッチ用のLogファイルに分割しました。14ファイルまで溜まります。

ついでに宣伝用のバリデーション追加。