### PR TITLE
[feature] ユーザー削除のバッチ処理を追加

### DIFF
--- a/backend/app/Console/Commands/UserDelete.php
+++ b/backend/app/Console/Commands/UserDelete.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
+
+class UserDelete extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'user:delete';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '作成から7年経ったユーザを削除する';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        // トランザクションの開始
+        DB::transaction(function () {
+            # 戻り値は削除件数
+            $delete_users = user::whereDate('created_at', '>', date('Y-m-d', strtotime('-7 year')))->delete();
+            $message = '[' . date('Y-m-d h:i:s') . '] ユーザー ： ' . $delete_users . '件削除';
+
+            //INFOレベルでメッセージを出力
+            $this->info($message);
+            //ログを書き出す
+            Log::setDefaultDriver('batch');
+            Log::info($message);
+        });
+    }
+}

--- a/backend/app/Console/Commands/UserDelete.php
+++ b/backend/app/Console/Commands/UserDelete.php
@@ -43,7 +43,7 @@ class UserDelete extends Command
         // トランザクションの開始
         DB::transaction(function () {
             # 戻り値は削除件数
-            $delete_users = user::whereDate('created_at', '>', date('Y-m-d', strtotime('-7 year')))->delete();
+            $delete_users = user::whereDate('created_at', '<', date('Y-m-d', strtotime('-7 year')))->delete();
             $message = '[' . date('Y-m-d h:i:s') . '] ユーザー ： ' . $delete_users . '件削除';
 
             //INFOレベルでメッセージを出力

--- a/backend/app/Console/Commands/UserDelete.php
+++ b/backend/app/Console/Commands/UserDelete.php
@@ -43,7 +43,7 @@ class UserDelete extends Command
         // トランザクションの開始
         DB::transaction(function () {
             # 戻り値は削除件数
-            $delete_users = user::whereDate('created_at', '<', date('Y-m-d', strtotime('-7 year')))->delete();
+            $delete_users = user::whereDate('created_at', '<', now()->subYears(7))->delete();
             $message = '[' . date('Y-m-d h:i:s') . '] ユーザー ： ' . $delete_users . '件削除';
 
             //INFOレベルでメッセージを出力

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -28,6 +28,9 @@ class Kernel extends ConsoleKernel
         // 毎日深夜0時に掲載期間が終了した募集と宣伝を削除
         $schedule->command('offer:delete')->daily();
         $schedule->command('promotion:delete')->daily();
+
+        // 年度始め(4月1日)に7年経過ユーザーを削除
+        $schedule->command('user:delete')->yearlyOn(4, 1, '00:00');
     }
 
     /**

--- a/backend/database/migrations/2021_11_12_081528_create_offers_table.php
+++ b/backend/database/migrations/2021_11_12_081528_create_offers_table.php
@@ -24,7 +24,7 @@ class CreateOffersTable extends Migration
             $table->date('post_date');
             $table->date('end_date');
             $table->unsignedBigInteger('student_number');
-            $table->foreign('student_number')->references('student_number')->on('users');
+            $table->foreign('student_number')->references('student_number')->on('users')->cascadeOnDelete();
             $table->string('user_class');
         });
     }

--- a/backend/database/migrations/2021_11_12_084853_create_promotions_table.php
+++ b/backend/database/migrations/2021_11_12_084853_create_promotions_table.php
@@ -22,7 +22,7 @@ class CreatePromotionsTable extends Migration
             $table->date('post_date');
             $table->date('end_date');
             $table->unsignedBigInteger('student_number');
-            $table->foreign('student_number')->references('student_number')->on('users');
+            $table->foreign('student_number')->references('student_number')->on('users')->cascadeOnDelete();
             $table->string('user_class');
         });
     }

--- a/backend/database/migrations/2021_11_12_085503_create_works_table.php
+++ b/backend/database/migrations/2021_11_12_085503_create_works_table.php
@@ -22,7 +22,7 @@ class CreateWorksTable extends Migration
             $table->string('link')->nullable();
             $table->date('post_date');
             $table->unsignedBigInteger('student_number');
-            $table->foreign('student_number')->references('student_number')->on('users');
+            $table->foreign('student_number')->references('student_number')->on('users')->cascadeOnDelete();
         });
     }
 


### PR DESCRIPTION
年度始め(4月1日)に作成から7年経過したユーザーを削除します。
ついでに募集、宣伝、作品テーブルにcascadeを追加