### PR TITLE
応募者に送信する応募完了メールを作成

### DIFF
--- a/backend/app/Http/Controllers/OfferController.php
+++ b/backend/app/Http/Controllers/OfferController.php
@@ -158,7 +158,7 @@ class OfferController extends Controller
         if ($owner_student_number === $applicant_student_number) {
             return response()->json(
                 [
-                    'message' => 'Owner and applicant are the same.',
+                    'message' => '応募者と募集主が同一です。',
                 ],
                 Response::HTTP_FORBIDDEN
             );

--- a/backend/app/Mail/OfferCompleted.php
+++ b/backend/app/Mail/OfferCompleted.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class OfferCompleted extends Mailable
+{
+    use Queueable, SerializesModels;
+    public $owner;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($owner)
+    {
+        $this->owner = $owner;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        # 現段階ではマークダウン記法で作成
+        return $this->markdown('mail.offer-completed')
+            ->with([
+                'student_number' => $this->owner->student_number,
+                'user_name' => $this->owner->user_name,
+                'title' => $this->owner->title,
+                'email' => $this->owner->email,
+            ])
+            # 件名
+            ->subject('募集主へ連絡が送信されました - Gawdi Board');
+    }
+}

--- a/backend/resources/views/mail/offer-completed.blade.php
+++ b/backend/resources/views/mail/offer-completed.blade.php
@@ -1,0 +1,33 @@
+@component('mail::message')
+# Gawdi Boardをご利用いただきありがとうございます。<br>
+# こちらは自動メッセージです。このメールには返信しないでください。<br>
+
+<div>
+
+## 募集<br>
+**「{{ $title }}」**<br>
+の募集主に連絡が送信されました。<br>
+
+## 募集主の情報<br>
+@component('mail::panel')
+学籍番号: {{ $student_number }}<br>
+ユーザーネーム: {{ $user_name }}<br>
+連絡先メールアドレス: {{ $email }}<br>
+@endcomponent
+
+<br>
+募集主からの返事はメールで届きます。<br>
+返事が届くまでお待ちください。<br>
+<br>
+
+<font size="2">
+募集主から返事が届かない場合、迷惑メールフォルダーをご確認ください。<br>
+募集主が何らかの理由で返事をしない場合がありますがご了承ください。<br>
+ユーザー同士のトラブルについてGawdi Board運営は一切の責任を負いかねます。相手を尊重し配慮のある会話を心がけていただきますようお願い致します。<br>
+</font>
+
+</div>
+<br>
+Thanks,<br>
+{{ config('app.name') }}
+@endcomponent


### PR DESCRIPTION
# 概要
応募時に応募者に完了メールを送信するロジックを応募送信APIに追加しました。
応募者と募集主が同一の場合は403を返すようにしています。

# そのうちやらなきゃいけないこと
- メールロジックをキューにぶち込む