### PR TITLE
[add] mysql初回起動時用shell追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ install-recommend-packages:
 	$(DC) exec app php artisan vendor:publish --provider="Barryvdh\Debugbar\ServiceProvider"
 init:
 	$(DC) up -d --build
+	sh ./infra/docker/mysql/init.sh
 	$(DC) exec app composer install
 	$(DC) exec app cp .env.example .env
 	$(DC) exec app php artisan key:generate

--- a/infra/docker/mysql/init.sh
+++ b/infra/docker/mysql/init.sh
@@ -1,0 +1,10 @@
+flag=true
+
+while $flag; do
+
+  if (docker compose -f ./docker-compose.yml logs | grep "MySQL\sinit\sprocess\sdone.\sReady\sfor\sstart\sup." > /dev/null 2>&1) ; then
+    echo "Mysql Ready"
+    flag=false
+  fi
+
+done


### PR DESCRIPTION
```
docker compose exec app php artisan migrate:fresh --seed

   Illuminate\Database\QueryException

  SQLSTATE[HY000] [2002] Connection refused (SQL: SHOW FULL TABLES WHERE table_type = 'BASE TABLE')

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:703
    699▕         // If an exception occurs when attempting to run a query, we'll format the error
    700▕         // message to include the bindings with SQL, which will make this exception a
    701▕         // lot more helpful to the developer instead of just the database's errors.
    702▕         catch (Exception $e) {
  ➜ 703▕             throw new QueryException(
    704▕                 $query, $this->prepareBindings($bindings), $e
    705▕             );
    706▕         }
    707▕     }

      +44 vendor frames
  45  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
make[1]: *** [Makefile:74: fresh] Error 1
make[1]: Leaving directory '/home/yume/codes/GawdiBoard-backend'
make: *** [Makefile:34: init] Error 2
```


## 説明
初回起動時に上記エラーが出たのでmysqlがReadyになるまで待つshellプログラムを追加した。
make init 時にsh で実行されるようにした。