### PR TITLE
make initをしたら自動的にswaggerをインストールする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,9 @@ init:
 	$(DC) exec app php artisan key:generate
 	$(DC) exec app php artisan storage:link
 	$(DC) exec app chown -R $$UNAME:$$UNAME bootstrap/cache
+	$(DC) exec app composer require "darkaonline/l5-swagger"
 	@make fresh
+	@make swagger
 remake:
 	@make destroy
 	@make init


### PR DESCRIPTION
現状だと新規にgit cloneした後にわざわざ `composer require` をしてswaggerをインストールする必要があるので  `make init` をした際に自動でswaggerのインストールと実行をするように設定しました