### PR TITLE
swaggerを8.1.0

### DIFF
--- a/backend/app/swagger.php
+++ b/backend/app/swagger.php
@@ -2,7 +2,7 @@
 
 /**
  * @OA\Info(
- *     version="8.0.9",
+ *     version="8.1.0",
  *     title="GawdiBoard API設計書",
  *     description="APIドキュメントとして参照　テスト実行ができます。",
  * )


### PR DESCRIPTION
composer.locの`l5-swagger`のバージョンが`8.1.0`なのでswaggerの説明も`8.1.0`にアップデート