### PR TITLE
composer formatするコマンドを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,3 +113,6 @@ swagger:
 
 update-packages:
 	$(DC) exec app composer update
+
+code-format:
+	$(DC) exec app composer format


### PR DESCRIPTION
`git hooks` で整形されないファイルを適宜整形するために `composer format`を実行するコマンドを追加