### PR TITLE
[Fix] 掲載期間が終了したデータの削除日付を修正

### DIFF
--- a/backend/app/Console/Commands/OfferDelete.php
+++ b/backend/app/Console/Commands/OfferDelete.php
@@ -42,8 +42,8 @@ class OfferDelete extends Command
     {
         // トランザクションの開始
         DB::transaction(function () {
-            # 戻り値は削除件数
-            $delete_offers = Offer::whereDate('end_date', '<', date('Y-m-d'))->delete();
+            # 戻り値は削除件数  掲載期間終了より1週間で削除
+            $delete_offers = Offer::whereDate('end_date', '<', date('Y-m-d', strtotime('-7 day')))->delete();
             $message = '[' . date('Y-m-d h:i:s') . '] 募集 : ' . $delete_offers . '件削除';
 
             //INFOレベルでメッセージを出力

--- a/backend/app/Console/Commands/PromotionDelete.php
+++ b/backend/app/Console/Commands/PromotionDelete.php
@@ -42,8 +42,8 @@ class PromotionDelete extends Command
     {
         // トランザクションの開始
         DB::transaction(function () {
-            # 戻り値は削除件数
-            $delete_promotions = Promotion::whereDate('end_date', '<', date('Y-m-d'))->delete();
+            # 戻り値は削除件数  掲載期間終了より1週間で削除
+            $delete_promotions = Promotion::whereDate('end_date', '<', date('Y-m-d', strtotime('-7 day')))->delete();
             $message = '[' . date('Y-m-d h:i:s') . '] 宣伝：' . $delete_promotions . '件削除';
 
             //INFOレベルでメッセージを出力

--- a/backend/app/Http/Controllers/OfferController.php
+++ b/backend/app/Http/Controllers/OfferController.php
@@ -129,6 +129,7 @@ class OfferController extends Controller
 
         # page番号 * 30件のデータを最新順で取得
         $fetched_offers = $fetched_offers
+            ->whereDate('end_date', '>=', date('Y-m-d'))
             ->latest('post_date')
             ->paginate(30);
 

--- a/backend/app/Http/Controllers/PromotionController.php
+++ b/backend/app/Http/Controllers/PromotionController.php
@@ -120,6 +120,7 @@ class PromotionController extends Controller
 
         # page番号 * 30件のデータを最新順で取得
         $fetched_promotions = $fetched_promotions
+            ->whereDate('end_date', '>=', date('Y-m-d'))
             ->latest('post_date')
             ->paginate(30);
 


### PR DESCRIPTION
### 概要
募集と宣伝のデータにおいて、掲載終了日と同日に削除していたのを掲載終了日より１週間後で削除するように修正しました。

それに伴って、募集と宣伝を取得する際に掲載終了日より前のデータのみ取得するように修正