### PR TITLE
[fix]ファイルアップロードapiのドキュメントにhttpエラー504を追加

### DIFF
--- a/backend/app/Http/Controllers/OthersController.php
+++ b/backend/app/Http/Controllers/OthersController.php
@@ -141,6 +141,10 @@ class OthersController extends Controller
      *      response=500,
      *      description="不正なエラー",
      *  ),
+     * @OA\Response(
+     *      response=504,
+     *      description="大きなファイルのアップロード時に処理がタイムアウトした",
+     * ),
      *  @OA\Response(
      *      response=200,
      *      description="お問い合わせが送信された",


### PR DESCRIPTION
[概要]
サーバエラーの際に504エラーが出たのでhttpコードを追加

[内容]
大きなファイルを送りサーバ側で処理しきれずにタイムアウトした場合や、サーバ自体がない場合にこのエラーが出る