### PR TITLE
[Fix] ログインユーザーと同一のリストではない場合に掲載終了した投稿は取得しない

### DIFF
--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -15,6 +15,7 @@ use App\Http\Resources\UserResource;
 use App\Http\Resources\OfferCollection;
 use App\Http\Resources\PromotionCollection;
 use App\Http\Resources\WorkCollection;
+use Illuminate\Support\Facades\Auth;
 
 class UserController extends Controller
 {
@@ -89,7 +90,15 @@ class UserController extends Controller
             'tags.targets',
             'users',
         ])
-            ->where('student_number', '=', $student_number)
+            ->where('student_number', '=', $student_number);
+
+        # ログインユーザーと同一のリストである = 掲載終了した募集も取得
+        if ($student_number !== Auth::id()) {
+            $fetched_user_offers = $fetched_user_offers
+                ->whereDate('end_date', '>', now());
+        }
+
+        $fetched_user_offers = $fetched_user_offers
             ->latest('post_date')
             ->get();
 
@@ -105,7 +114,15 @@ class UserController extends Controller
             'tags.targets',
             'users',
         ])
-            ->where('student_number', '=', $student_number)
+            ->where('student_number', '=', $student_number);
+
+        # ログインユーザーと同一のリストである = 掲載終了した宣伝も取得
+        if ($student_number !== Auth::id()) {
+            $fetched_user_promotions = $fetched_user_promotions
+                ->whereDate('end_date', '>', now());
+        }
+
+        $fetched_user_promotions = $fetched_user_promotions
             ->latest('post_date')
             ->get();
 


### PR DESCRIPTION
### 概要
APIのリクエスト時に、学生番号とログインユーザーの学籍番号が一致しない場合に、
掲載終了日の過ぎた投稿を取得しないように修正しました。