### PR TITLE
[Fix] ログインユーザー取得APIに投稿数を含めるように修正

### DIFF
--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -67,6 +67,13 @@ class UserController extends Controller
         $student_number = 2180418;
         $login_user = User::findOrFail($student_number);
 
+        # 投稿数を取得する
+        $user_offers_count = Offer::where('student_number', '=', $student_number)
+            ->count();
+        $user_promotions_count = Promotion::where('student_number', '=', $student_number)
+            ->count();
+        $login_user->posted_count = $user_offers_count + $user_promotions_count;
+
         return $login_user;
     }
 

--- a/backend/app/Http/Resources/UserResource.php
+++ b/backend/app/Http/Resources/UserResource.php
@@ -28,7 +28,7 @@ class UserResource extends JsonResource
             'email' => $this->email,
             'link' => $this->link,
             'self_introduction' => $this->self_introduction,
-            'created_at ' => $this->created_at,
+            'posted_count' => $this->posted_count,
         ];
     }
 }


### PR DESCRIPTION
### 概要
ログインユーザー取得API /api/user/whoami　に
ユーザーの募集と宣伝を合わせた投稿数 posted_count を含めるように修正しました。