### PR TITLE
[Fix] 投稿APIに投稿数のチェックを追加

### DIFF
--- a/backend/app/Http/Controllers/Controller.php
+++ b/backend/app/Http/Controllers/Controller.php
@@ -5,9 +5,30 @@ namespace App\Http\Controllers;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
+use App\Models\Offer;
+use App\Models\Promotion;
+use \Symfony\Component\HttpFoundation\Response;
 use Illuminate\Routing\Controller as BaseController;
 
 class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+
+    # ユーザーの投稿数をチェックし上限ならエラー
+    protected function validateUserPostedCount($student_number)
+    {
+        $user_offers_count = Offer::where('student_number', '=', $student_number)
+            ->count();
+        $user_promotions_count = Promotion::where('student_number', '=', $student_number)
+            ->count();
+
+        if (10 > $user_offers_count + $user_promotions_count) {
+            return response()->json(
+                [
+                    'message' => '投稿数が上限に達しています。',
+                ],
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+    }
 }

--- a/backend/app/Http/Controllers/OfferController.php
+++ b/backend/app/Http/Controllers/OfferController.php
@@ -174,10 +174,13 @@ class OfferController extends Controller
      */
     public function post(StoreOfferRequest $request)
     {
+        $student_number = 9073372;
+        $this->validateUserPostedCount($student_number);
+
         $created_offer = new Offer();
 
         // トランザクションの開始
-        DB::transaction(function () use ($request, $created_offer) {
+        DB::transaction(function () use ($request, $created_offer, $student_number) {
             $created_offer->title = $request->input('title');
             $created_offer->target = $request->input('target');
             $created_offer->job = $request->input('job');
@@ -187,7 +190,7 @@ class OfferController extends Controller
             $created_offer->user_class = $request->input('user_class');
             $created_offer->post_date = now()->format('Y-m-y');
             $created_offer->end_date = $request->input('end_date');
-            $created_offer->student_number = 2180418;
+            $created_offer->student_number = $student_number;
             $created_offer->save();
 
             $created_offer->tags()->sync($request->input('offer_tag_ids'));

--- a/backend/app/Http/Controllers/PromotionController.php
+++ b/backend/app/Http/Controllers/PromotionController.php
@@ -165,10 +165,13 @@ class PromotionController extends Controller
      */
     public function post(StorePromotionRequest $request)
     {
+        $student_number = 9073372;
+        $this->validateUserPostedCount($student_number);
+
         $created_promotion = new Promotion();
 
         // トランザクションの開始
-        DB::transaction(function () use ($request, $created_promotion) {
+        DB::transaction(function () use ($request, $created_promotion, $student_number) {
             $created_promotion->title = $request->input('title');
             $created_promotion->note = $request->input('note');
             $created_promotion->picture = $request->input('picture');
@@ -176,7 +179,7 @@ class PromotionController extends Controller
             $created_promotion->user_class = $request->input('user_class');
             $created_promotion->post_date = now()->format('Y-m-y');
             $created_promotion->end_date = $request->input('end_date');
-            $created_promotion->student_number = 2180418;
+            $created_promotion->student_number = $student_number;
             $created_promotion->save();
 
             $created_promotion->tags()->sync($request->input('promotion_tag_ids'));


### PR DESCRIPTION
### 概要
募集投稿APIと宣伝投稿APIに、
ユーザーの投稿数をバリデーションし、上限ならエラーを返す処理を追加。

継承元のコントローラーにメソッドを追加しています。