### PR TITLE
[Add] cron用コンテナ作成

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ web:
 	$(DC) exec web bash
 app:
 	$(DC) exec app bash
+cron:
+	$(DC) exec cron bash
 migrate:
 	$(DC) exec app php artisan migrate
 fresh:

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -8,7 +8,6 @@ use \App\Console\Commands\OfferDelete;
 use \App\Console\Commands\PromotionDelete;
 use \App\Console\Commands\SendDeleteEmail;
 use \App\Console\Commands\UserDelete;
-use \App\Console\Commands\WriteLog;
 
 class Kernel extends ConsoleKernel
 {
@@ -22,7 +21,6 @@ class Kernel extends ConsoleKernel
         PromotionDelete::class,
         SendDeleteEmail::class,
         UserDelete::class,
-        WriteLog::class,
     ];
 
     /**

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -4,6 +4,11 @@ namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use \App\Console\Commands\OfferDelete;
+use \App\Console\Commands\PromotionDelete;
+use \App\Console\Commands\SendDeleteEmail;
+use \App\Console\Commands\UserDelete;
+use \App\Console\Commands\WriteLog;
 
 class Kernel extends ConsoleKernel
 {
@@ -13,7 +18,11 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        OfferDelete::class,
+        PromotionDelete::class,
+        SendDeleteEmail::class,
+        UserDelete::class,
+        WriteLog::class,
     ];
 
     /**
@@ -25,13 +34,46 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         // バッチ処理するコマンドをここに記述する
-        // 毎日深夜0時に掲載期間が終了した募集と宣伝を削除
-        $schedule->command('offer:delete')->daily();
-        $schedule->command('promotion:delete')->daily();
+        // 毎日深夜0時掲載期間が終了した募集を削除
+        $schedule->command('offer:delete')
+            // 毎日深夜0時
+            ->daily()
+            // 環境(APP_ENV)がstagingかproductionの場合に実行
+            ->environments(['staging', 'production'])
+            // バックグラウンド実行
+            ->runInBackground();
+        // 失敗時にメールを送信する。
+        // ->emailOutputOnFailure('akisu1016@gmail.com');
+
+        // 毎日深夜0時掲載期間が終了した宣伝を削除
+        $schedule->command('promotion:delete')
+            ->daily()
+            // 環境(APP_ENV)がstagingかproductionの場合に実行
+            ->environments(['staging', 'production'])
+            // バックグラウンド実行
+            ->runInBackground();
+        // 失敗時にメールを送信する。
+        // ->emailOutputOnFailure('sample@gmail.com');
+
         // 毎日11時に掲載終了3日前と当日の投稿主にメールを送信
-        $schedule->command('send:delete-email')->dailyAt('11:00');
+        $schedule->command('send:delete-email')
+            ->dailyAt('11:00')
+            // 環境(APP_ENV)がstagingかproductionの場合に実行
+            ->environments(['staging', 'production'])
+            // バックグラウンド実行
+            ->runInBackground();
+        // 失敗時にメールを送信する。
+        // ->emailOutputOnFailure('sample@gmail.com');
+
         // 年度始め(4月1日)に7年経過ユーザーを削除
-        $schedule->command('user:delete')->yearlyOn(4, 1, '00:00');
+        $schedule->command('user:delete')
+            ->yearlyOn(4, 1, '00:00')
+            // 環境(APP_ENV)がstagingかproductionの場合に実行
+            ->environments(['staging', 'production'])
+            // バックグラウンド実行
+            ->runInBackground();
+        // 失敗時にメールを送信する。
+        // ->emailOutputOnFailure('sample@gmail.com');
     }
 
     /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     build:
       context: .
       dockerfile: ./infra/docker/php/Dockerfile
+    tty: true
     container_name: 'gawdiboard-app'
     volumes:
       - type: volume
@@ -31,8 +32,6 @@ services:
       - DB_DATABASE=${DB_NAME:-laravel_local}
       - DB_USERNAME=${DB_USER:-phper}
       - DB_PASSWORD=${DB_PASS:-secret}
-    command: > 
-      bash -c 'php artisan queue:work'
 
   web:
     build:
@@ -78,3 +77,26 @@ services:
       - MYSQL_USER=${DB_USER:-phper}
       - MYSQL_PASSWORD=${DB_PASS:-secret}
       - MYSQL_ROOT_PASSWORD=${DB_PASS:-secret}
+
+  cron:
+    build:
+      context: .
+      dockerfile: ./infra/docker/cron/Dockerfile
+    tty: true
+    container_name: 'gawdiboard-cron'
+    volumes:
+      - type: volume
+        source: php-fpm-socket
+        target: /var/run/php-fpm
+        volume:
+          nocopy: true
+      - type: bind
+        source: ./backend
+        target: /work/backend
+      - type: volume
+        source: psysh-store
+        target: /root/.config/psysh
+        volume:
+          nocopy: true
+    depends_on:
+      - app

--- a/infra/docker/cron/Dockerfile
+++ b/infra/docker/cron/Dockerfile
@@ -1,0 +1,25 @@
+FROM php:8.0.12-fpm-bullseye
+
+# timezone environment
+ENV TZ='Asia/Tokyo' \
+    # locale
+    LANG=ja_JP.UTF-8 \
+    LANGUAGE=ja_JP:ja \
+    LC_ALL=ja_JP.UTF-8 \
+    # composer environment
+    COMPOSER_ALLOW_SUPERUSER=1 \
+    COMPOSER_HOME=/composer
+
+COPY --from=composer:2.1 /usr/bin/composer /usr/bin/composer
+
+# cronインストール
+RUN apt-get update && apt-get install -y cron
+
+# cron設定を配置する
+COPY ./infra/docker/cron/cron.root /etc/cron.d/cron
+
+# ログを標準出力へ出力できるようにシンボリックリンクを作成する
+RUN chmod 0644 /etc/cron.d/cron && ln -sf /proc/1/fd/1 /var/log/cron.log
+
+# フォアグラウンドでcronを起動する
+CMD cron -f

--- a/infra/docker/cron/cron.root
+++ b/infra/docker/cron/cron.root
@@ -1,0 +1,1 @@
+* * * * * root cd /work/backend && /usr/local/bin/php artisan schedule:run >> /var/log/cron.log 2>&1


### PR DESCRIPTION
### 概要
バッチ処理を定期実行するためのcron用コンテナを作成
再ビルドの必要がありますが　cronが　php artisan schedule:run  を毎分実行してくれます。