### PR TITLE
laravel wokerを監視するコンテナを作成

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ app:
 	$(DC) exec app bash
 cron:
 	$(DC) exec cron bash
-supervisor:
-	$(DC) exec supervisor bash
+worker:
+	$(DC) exec worker bash
 migrate:
 	$(DC) exec app php artisan migrate
 fresh:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ install-recommend-packages:
 	$(DC) exec app php artisan vendor:publish --provider="Barryvdh\Debugbar\ServiceProvider"
 init:
 	$(DC) up -d --build
-	sh ./infra/docker/mysql/init.sh
 	$(DC) exec app composer install
 	$(DC) exec app cp .env.example .env
 	$(DC) exec app php artisan key:generate
@@ -72,6 +71,8 @@ app:
 	$(DC) exec app bash
 cron:
 	$(DC) exec cron bash
+supervisor:
+	$(DC) exec supervisor bash
 migrate:
 	$(DC) exec app php artisan migrate
 fresh:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,3 +100,33 @@ services:
           nocopy: true
     depends_on:
       - app
+
+  supervisor:
+    build:
+      context: .
+      dockerfile: ./infra/docker/php/Dockerfile
+    tty: true
+    container_name: 'gawdiboard-supervisor'
+    volumes:
+      - type: volume
+        source: php-fpm-socket
+        target: /var/run/php-fpm
+        volume:
+          nocopy: true
+      - type: bind
+        source: ./backend
+        target: /work/backend
+      - type: volume
+        source: psysh-store
+        target: /root/.config/psysh
+        volume:
+          nocopy: true
+    entrypoint: [ "php", "artisan", "queue:listen" ]
+    restart: unless-stopped
+    environment:
+      - DB_CONNECTION=mysql
+      - DB_HOST=db
+      - DB_PORT=3306
+      - DB_DATABASE=${DB_NAME:-laravel_local}
+      - DB_USERNAME=${DB_USER:-phper}
+      - DB_PASSWORD=${DB_PASS:-secret}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,12 +101,12 @@ services:
     depends_on:
       - app
 
-  supervisor:
+  worker:
     build:
       context: .
       dockerfile: ./infra/docker/php/Dockerfile
     tty: true
-    container_name: 'gawdiboard-supervisor'
+    container_name: 'gawdiboard-worker'
     volumes:
       - type: volume
         source: php-fpm-socket


### PR DESCRIPTION
### 概要
appコンテナでLaravel queue worker を動かしてもエラー落ちした時に自動再起動できないので、
監視用のコンテナを作成しました。
supervisor を使えと公式ドキュメントには書かれていますが、こっちのがお手軽で、要件的にも問題ないと思われます。
マージした場合はコンテナ作り直してください
