### PR TITLE
[add] ユーザーアイコンを対応

### DIFF
--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -80,6 +80,7 @@ class UserController extends Controller
             $registed_user->user_name = $request->input('user_name');
             $registed_user->link = $request->input('link');
             $registed_user->self_introduction = $request->input('self_introduction');
+            $registed_user->icon = $request->input('icon');
             $registed_user->registered_flg = true;
             $registed_user->save();
         });
@@ -143,6 +144,7 @@ class UserController extends Controller
             $updated_user->user_name = $request->input('user_name');
             $updated_user->link = $request->input('link');
             $updated_user->self_introduction = $request->input('self_introduction');
+            $updated_user->icon = $request->input('icon');
             $updated_user->save();
         });
 

--- a/backend/app/Http/Documents/User.php
+++ b/backend/app/Http/Documents/User.php
@@ -30,6 +30,12 @@
  *           example="私はECC太郎です。ITのことなら全部できます。",
  *           description="自己紹介",
  *       ),
+ *      @OA\Property(
+ *           property="icon",
+ *           type="string",
+ *           example="backend/public/picture/icon.png",
+ *           description="ユーザーのアイコン",
+ *       ),
  *   ),
  * ),
  */
@@ -58,6 +64,11 @@
  *           example="私はECC花子になりました。やっぱりITできません。",
  *           description="自己紹介",
  *       ),
+ *       @OA\Property(
+ *           property="icon",
+ *           type="string",
+ *           example="backend/public/picture/icon.png",
+ *           description="ユーザーのアイコン",
  *   ),
  * ),
  */

--- a/backend/app/Http/Requests/StoreUserProfileRequest.php
+++ b/backend/app/Http/Requests/StoreUserProfileRequest.php
@@ -27,6 +27,7 @@ class StoreUserProfileRequest extends FormRequest
             'user_name' => ['required', 'string', 'max:50'],
             'link' => ['present', 'url', 'max:255'],
             'self_introduction' => ['present', 'string', 'max:255'],
+            'icon' => ['present', 'string', 'max:255'],
         ];
     }
 }

--- a/backend/app/Http/Requests/UpdateUserProfileRequest.php
+++ b/backend/app/Http/Requests/UpdateUserProfileRequest.php
@@ -27,6 +27,7 @@ class UpdateUserProfileRequest extends FormRequest
             'user_name' => ['required', 'string', 'max:50'],
             'link' => ['present', 'url', 'max:255'],
             'self_introduction' => ['present', 'string', 'max:255'],
+            'icon' => ['present', 'string', 'max:255'],
         ];
     }
 }

--- a/backend/app/Http/Resources/UserResource.php
+++ b/backend/app/Http/Resources/UserResource.php
@@ -29,6 +29,7 @@ class UserResource extends JsonResource
             'link' => $this->link,
             'self_introduction' => $this->self_introduction,
             'registered_flg' => $this->registered_flg,
+            'icon' => $this->icon,
             'posted_count' => $this->posted_count,
         ];
     }

--- a/backend/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/backend/database/migrations/2014_10_12_000000_create_users_table.php
@@ -21,6 +21,7 @@ class CreateUsersTable extends Migration
             $table->string('link')->nullable();
             $table->string('self_introduction')->nullable();
             $table->boolean('registered_flg')->default(false);
+            $table->string('picture');
             $table->timestamps();
             $table->dropColumn('updated_at');
         });


### PR DESCRIPTION
### 概要
ユーザープロフィールにiconを追加し、プロフィール登録API・プロフィール編集APIをiconに対応させました。
リクエストには画像アップロードAPIの返却値のURLを入れてください。